### PR TITLE
fix typos & images on GitHub Pages links

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,5 @@ Welcome to the GitHub repository for advanced vSphere Supervisor documentation! 
 * Supervisor Troubleshooting Resources
   * [Supervisor Troubleshooting Guide](/supervisor-troubleshooting.md)
   * [VKS Troubleshooting Guide](/vks-troubleshooting.md)
-  * [VM Service Troubleshooting Guide](/vm-service-troubleshooting)
-  * others
 * [NSX Requirements for Supervisor](/nsx-requirements.md)
 * [Custom Cluster Class](/custom-cluster-class.md)

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,6 @@
+title: "vSphere Supervisor"
+description: "Advanced documentation for vSphere Supervisor"
+url: "https://vmware.github.io"
+baseurl: "/vsphere-supervisor"
+
+theme: jekyll-theme-minimal

--- a/airgapped/air-gapped-harbor.md
+++ b/airgapped/air-gapped-harbor.md
@@ -19,7 +19,7 @@ We may not have an Enterprise registry available for the platform deployment in 
 
 The data flow of packages, binaries, and images between the internet-connected and air-gapped environment can be summarized by the picture below -
 
-![image](/airgapped/harbor-dataflow.png)
+![image](harbor-dataflow.png)
 
 ## Terminology
 * **Bootstrap registry** An OCI-compliant Harbor registry will be deployed on the vCenter. This registry will be used exclusively to upload the binaries necessary to enable Contour and Harbor Supervisor services on the Supervisor. It will not be utilized for any other purpose.
@@ -143,8 +143,8 @@ sudo echo "$certtext" > /opt/bitnami/nginx/conf/bitnami/certs/server.crt
 #
 sudo /opt/bitnami/ctlscript.sh restart bitnami.nginx
 ```
-* The value of `certtext` has to be updated with the contents of `registory0.crt` (including `-----BEGIN CERTIFICATE-----` and ending with `-----END CERTIFICATE-----`). 
-* The value of `keytext`  has to be updated with the contents of `registory0.key` (including `-----BEGIN PRIVATE KEY-----` and ending with `-----END PRIVATE KEY-----`). 
+* The value of `certtext` has to be updated with the contents of `registry0.crt` (including `-----BEGIN CERTIFICATE-----` and ending with `-----END CERTIFICATE-----`).
+* The value of `keytext` has to be updated with the contents of `registry0.key` (including `-----BEGIN PRIVATE KEY-----` and ending with `-----END PRIVATE KEY-----`).
 * If the above process was not used to generate the self-signed certificates and key files, the contents can be replaced with the user-provided certificate and key file. 
 
 Once the above file has been successfully created, please run the following command to encode (BASE64) it and copy its contents.  
@@ -160,20 +160,20 @@ Deploying the Bitnami Harbor OVA follows the same process as deploying any other
 - When providing an IP address, use the IP/netmask format. 
 - In the `User data to be made available inside the instance` field, paste the content of the base64-encoded output captured in the previous command. 
 
-![image](/airgapped/bitnami0.png)
+![image](bitnami0.png)
 
 Once Harbor is deployed and running, we can grab the default credentials from the VM’s console. SSH into the VM using the `bitnami` user and update the credentials using a secure password. Login to the Harbor UI using the `admin` user and the password provided, and update the credentials using a secure password. See the example below - 
 
-![image](/airgapped/bitnami1.png)
+![image](bitnami1.png)
 
 ### Add the Bootstrap Registry certificate to the Supervisor
 The Supervisor must trust the Bootstrap registry certificate. To perform this step, navigate to Workload Management -> Supervisor -> Configure -> Container Registries. Click on Add Registry. 
 
-![image](/airgapped/add-cert2.png)
+![image](add-cert2.png)
 
 Input the Registry host URL, TLS Certificate of the registry (the content of `registry0.crt`), Username, and Password. Note that while the UI states that the Username and Password are optional, they are currently mandatory.
 
-![image](/airgapped/add-cert3.png)
+![image](add-cert3.png)
 
 ### Add the Bootstrap Registry certificate to the Admin host Trust Store
 You can use the commands below to add the Bootstrap Harbor certificate to the Admin host trust store. 
@@ -217,7 +217,7 @@ tanzu imgpkg copy --tar contour-v1.28.2.tar --to-repo registry0.env1.lab.test/su
 tanzu imgpkg copy --tar harbor-v2.9.1.tar   --to-repo registry0.env1.lab.test/sup-services/harbor  --cosign-signatures
 ```
 
-Additionally, the corresponding Contour and Harbor Supervisor Service YAMsL needs to be updated with the new Bootstrap registry valid location -
+Additionally, the corresponding Contour and Harbor Supervisor Service YAMLs need to be updated with the new Bootstrap registry valid location -
 
 ```yaml
 # Contour.yaml

--- a/airgapped/air-gapped-vcf91.md
+++ b/airgapped/air-gapped-vcf91.md
@@ -17,7 +17,7 @@ The procedure involves the following major steps:
 
 The data flow of packages, binaries, and images between the internet-connected and air-gapped environments is summarized in the diagram below.
 
-![image](/airgapped/depotreg-dataflow.png)
+![image](depotreg-dataflow.png)
 
 ## Terminology
 * **Bastion host** &mdash; A host (typically a Linux VM) that is connected to the Internet, or has access to download packages, binaries, and images from the Internet.

--- a/airgapped/air-gapped.md
+++ b/airgapped/air-gapped.md
@@ -15,9 +15,9 @@ The complete procedure to install a VKS cluster with additional Tanzu package ad
 
 The data flow of packages, binaries, and images between the internet-connected and air-gapped environment can be summarized by the picture below -
 
-![image](/airgapped/ocireg-dataflow.png)
+![image](ocireg-dataflow.png)
 
-## Terminiology
+## Terminology
 * **Bastion Host** A host (preferably a Linux VM) that is connected to the Internet or has access to download packages, binaries, and images from the Internet.
 * **Admin Host** A host (preferably a Linux VM) within the air-gapped environment without internet access. The Admin host generally has network connectivity to all the hosts in the air-gapped environment. Files downloaded from the Internet to the Bastion host are transferred to the Admin Machine, and administrators can use it to interact with the platform.
 * **Tanzu CLI** A plugin-based CLI that is used to interact with the Supervisor and VKS clusters
@@ -56,7 +56,7 @@ Additionally, it is crucial to have the following packages and binaries installe
 This document utilizes an Ubuntu 24.04.4-based Bastion host (**bastion.internet.lab.test**) for this stage. Below are the key plugins and packages that must be downloaded, each playing a critical role in the platform deployment process.
 
 ### 1a. Kubernetes Release OVA files
-Kubernetes releases provide the Kubernetes software distribution for VKS clusters. VMware distributes Kubernetes releases as virtual machine templates, which you synchronize with the platform using a vCenter Content Library. Download the latest Kubernetes release files from https://wp-content.vmware.com/v2/latest/. The versions to be downloaded may depend on the workload requirements. It would be best to download three or more of the latest versions. Follow [Step #11 from the official docuentation](https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere-supervisor/8-0/using-tkg-service-with-vsphere-supervisor/administering-kubernetes-releases-for-tkg-service-clusters/create-a-local-content-library-for-air-gapped-cluster-provisioning.html) to download the relevant Kubernetes release files for each version.  
+Kubernetes releases provide the Kubernetes software distribution for VKS clusters. VMware distributes Kubernetes releases as virtual machine templates, which you synchronize with the platform using a vCenter Content Library. Download the latest Kubernetes release files from https://wp-content.vmware.com/v2/latest/. The versions to be downloaded may depend on the workload requirements. It would be best to download three or more of the latest versions. Follow [Step #11 from the official documentation](https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere-supervisor/8-0/using-tkg-service-with-vsphere-supervisor/administering-kubernetes-releases-for-tkg-service-clusters/create-a-local-content-library-for-air-gapped-cluster-provisioning.html) to download the relevant Kubernetes release files for each version.
 
 ### 1b. Tanzu CLI and Plugins
 While the Tanzu CLI and its plugins will be installed on the Bastion host (`bastion.internet.lab.test`), they must also be copied to the Admin Machine as part of the file transfer process. When this document was written, Tanzu CLI v1.1.0 was supported with vSphere v8.0.3. The steps below involve installing the Tanzu CLI on the Bastion host, which is necessary to download the Tanzu CLI plugins. The installation of the Tanzu vSphere Plugin is mandatory. Other plugins can be downloaded and installed as required. Depending on your entitlements, the required Tanzu CLI binary can also be downloaded from the Broadcom website. Please have a look at the link for additional information. 
@@ -116,7 +116,7 @@ spec:
 ```
 For additional information and examples, please refer to [Steps 1, 2 and 3 of the official documentation](https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere-supervisor/8-0/vsphere-supervisor-services-and-workloads-8-0/deploying-supervisor-services-from-a-private-container-image-registry/relocate-supervisor-services-to-a-private-registry.html). While the official documentation refers to the `imgpkg` binary to perform the download function, the Tanzu CLI's `imgpkg plugin` performs the identical function. 
 
-####, E.g., Download Contour Supervisor Service Binaries and associated YAML files.
+#### E.g., Download Contour Supervisor Service Binaries and associated YAML files.
 When writing this document, the latest version of the Contour Supervisor Service is “v1.28.2”. Please refer to ​​the vSphere Supervisor Services page to check for the updated versions. Download the `contour.yml` and `contour-data-values.yml` files required for the Contour Supervisor Service. These files can be accessed through the vSphere Supervisor Services page. The `contour.yml` file can be obtained by selecting the appropriate Contour version, and the `contour-data-values.yml` can be downloaded from the "Contour Sample values.yaml" section in the same vSphere Supervisor Services page. Locate the value of the image from the `contour.yml` file as described above. 
 
 You can execute the following command from the Bastion host to download the image bundle as a tarball.
@@ -246,7 +246,7 @@ tanzu plugin source update default --uri registry1.env1.lab.test/tanzu_cli/plugi
 ## Install the Plugins
 tanzu plugin install –group vmware-vsphere/default:v8.0.3
  
-## Validate the existace of plugin files in the folder
+## Validate the existence of plugin files in the folder
 ls -al ~/.local/share/tanzu-cli/
 tanzu plugin list
 ```
@@ -254,11 +254,11 @@ tanzu plugin list
 ## 6. Add the Enterprise Registry certificate to the Supervisor (Optional)
 The Supervisor must trust the Enterprise registry certificate. This step is optional and required only when using a certificate not signed by a trusted Certificate authority (e.g., a self-signed certificate). To perform this step, navigate to Workload Management -> Supervisor -> Configure -> Container Registries. Click on Add Registry. 
 
-![image](/airgapped/add-cert0.png)
+![image](add-cert0.png)
 
 Input the Registry host URL, TLS Certificate of the registry (the content of `registry1.crt`), Username, and Password. Note that while the UI states that the Username and Password are optional, they are currently mandatory.
 
-![image](/airgapped/add-cert1.png)
+![image](add-cert1.png)
 
 ## 7. Upload Packages to the Enterprise registry
 Create two projects/folders, with public access, within the registry to upload -

--- a/nsx-requirements.md
+++ b/nsx-requirements.md
@@ -205,7 +205,7 @@ Pre-requisites for NSX Edge Transport Creation
 
 After successfully creating two 2 Edge Transports, create an Edge Cluster and add the NSX Edge Transport Node to the Edge Cluster.
 
-- Documentation Reference \- [Create NSX Edge](https://techdocscluster's.com/us/en/vmware-cis/nsx/vmware-nsx/4-2/installation-guide/installing-nsx-edge.html) 
+- Documentation Reference \- [Create NSX Edge](https://techdocs.broadcom.com/us/en/vmware-cis/nsx/vmware-nsx/4-2/installation-guide/installing-nsx-edge.html)
 - Documentation Reference \- [Create NSX Edge Cluster](https://techdocs.broadcom.com/us/en/vmware-cis/nsx/vmware-nsx/4-2/installation-guide/installing-nsx-edge/create-an-edge-cluster.html)
 
 ### NSX T0 Router

--- a/supervisor-troubleshooting.md
+++ b/supervisor-troubleshooting.md
@@ -163,7 +163,7 @@ $ kubectl logs <pod-name> -n <namespace>
 # Pod Logs Bundle of a Namespace
 $ kubectl cluster-info dump -n <namespace> --output directory=/PATH/NEWDIRECTORYNAME
 
-# Check CPU & Memeory by Node
+# Check CPU & Memory by Node
 $ kubectl top nodes
 ```
 


### PR DESCRIPTION
- Add _config.yml file to specify the GitHub Pages project baseurl (/vsphere-supervisor).
- Fix typos
- Fix links to images (need to be relative to the directory)
- Remove dangling links

-> This should make the https://vmware.github.io/vsphere-supervisor/airgapped/air-gapped.html render the actual images properly

Testing Done:

To test locally once Gemfile is added:
  bundle install
  bundle exec jekyll serve --baseurl ""
  `$ open http://localhost:4000`