### PR TITLE
GitHub pages: restore the default theme

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,4 +3,4 @@ description: "Advanced documentation for vSphere Supervisor"
 url: "https://vmware.github.io"
 baseurl: "/vsphere-supervisor"
 
-theme: jekyll-theme-minimal
+theme: jekyll-theme-primer


### PR DESCRIPTION
Use "jekyll-theme-primer" to have wide columns
instead.

Testing Done: ran `bundle install; bundle exec jekyll serve` and navigate to http://127.0.0.1:4000/vsphere-supervisor/port-and-protocols.html to check the layout is correct.